### PR TITLE
fix(events): infinite idle timeout so event listener never aborts

### DIFF
--- a/src/Client/DockerApiClientWrapper.php
+++ b/src/Client/DockerApiClientWrapper.php
@@ -43,7 +43,14 @@ final class DockerApiClientWrapper
         $client = $this->eventStreamClient ?? HttpClient::create([
             'base_uri' => $this->baseUri,
             'bindto'   => $this->socketPath,
-            'timeout'  => null,
+            // Infinite idle timeout. The Docker event stream is long-lived and
+            // often silent for minutes. A finite timeout (php.ini
+            // default_socket_timeout, 60s by default) ends the stream on idle,
+            // so listenForEvents() returns and the process exits — under a
+            // "restart: always" container that shows up as a restart every 60s.
+            // -1 disables the idle timeout, so the listener blocks until a real
+            // event or a genuine end-of-stream arrives.
+            'timeout'  => -1,
         ]);
 
         $serializer = new Serializer(


### PR DESCRIPTION
## Problem

`DockerApiClientWrapper::listenForEvents()` created the event-stream HTTP client with `'timeout' => null`, which Symfony resolves to `php.ini default_socket_timeout` (60s). The Docker `/events` stream is long-lived and often silent for minutes, so on idle the stream ended, `listenForEvents()` returned, and the CLI process exited. Under a `restart: always` container (e.g. docker-hostfile-sync) this looked like the container **restarting every 60s**.

## Fix

Set `'timeout' => -1` on the event-stream client to disable the idle timeout. The listener now blocks until a real event or a genuine end-of-stream arrives. The event listener's timeout is always infinite.

## Verification

- Control, `timeout=5` against real `/events`: `TIMEOUT@5s` (idle timeout mechanism fires).
- Fix, `timeout=-1`: silent >100s, **zero** timeout chunks emitted → never aborts.
- `composer cs:fix` (0 changes), `composer stan` (no errors), `composer test` (11/11 pass).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/WebProject-xyz/codesmith/php-docker-api-client/pr/272"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786984911&installation_id=131774636&pr_number=272&repository=WebProject-xyz%2Fphp-docker-api-client&return_to=https%3A%2F%2Fgithub.com%2FWebProject-xyz%2Fphp-docker-api-client%2Fpull%2F272&signature=2cd5c836e7e7c07f219995f4dd14738b18953890cbafb0025c96a384703b0474"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->